### PR TITLE
Add support in LinuxPBA for also unlocking OPAL Enterprise SSC disks.

### DIFF
--- a/LinuxPBA/UnlockSEDs.cpp
+++ b/LinuxPBA/UnlockSEDs.cpp
@@ -22,6 +22,7 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 #include "DtaDevGeneric.h"
 #include "DtaDevOpal1.h"
 #include "DtaDevOpal2.h"
+#include "DtaDevEnterprise.h"
 
 #include <dirent.h>
 #include <fnmatch.h>
@@ -62,7 +63,7 @@ uint8_t UnlockSEDs(char * password) {
         if (!tempDev->isPresent()) {
             break;
         }
-        if ((!tempDev->isOpal1()) && (!tempDev->isOpal2())) {
+        if (!tempDev->isAnySSC()) {
             printf("Drive %-10s %-40s not OPAL  \n", devref, tempDev->getModelNum());
 
             delete tempDev;
@@ -70,13 +71,15 @@ uint8_t UnlockSEDs(char * password) {
         }
         if (tempDev->isOpal2())
             d = new DtaDevOpal2(devref);
-        else
+        else if (tempDev->isOpal1())
             d = new DtaDevOpal1(devref);
+        else
+            d = new DtaDevEnterprise(devref);
         delete tempDev;
         d->no_hash_passwords = false;
         failed = 0;
         if (d->Locked()) {
-            if (d->MBREnabled()) {
+            if (!d->isEprise() && d->MBREnabled()) {
                 if (d->setMBRDone(1, password)) {
                     failed = 1;
                 }


### PR DESCRIPTION
Even though Enterprise drives don't have any Shadow MBR themselves, they can be installed in systems together with drives that have it, in which case it can be conventient to unlock all drives at once.

This code is essentially copied from the code in sedutil.cpp, which already handles Enterprise in addition to OPAL 1.0 and OPAL 2.0 SSC.